### PR TITLE
Add ROCM_SMI_BUILD_DOCS option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ cmake_minimum_required(VERSION 3.6.3)
 set(AMD_SMI_LIBS_TARGET "amd_smi_libraries")
 
 set ( BUILD_SHARED_LIBS ON CACHE BOOL "Build shared library (.so) or not.")
+set ( ROCM_SMI_BUILD_DOCS OFF CACHE BOOL "Build documentation")
 
 ## Set default module path if not already set
 if(NOT DEFINED CMAKE_MODULE_PATH)
@@ -137,6 +138,12 @@ set(CMN_INC_LIST ${CMN_INC_LIST} "${COMMON_INC_DIR}/rocm_smi_kfd.h")
 set(CMN_INC_LIST ${CMN_INC_LIST} "${COMMON_INC_DIR}/rocm_smi_io_link.h")
 set(CMN_INC_LIST ${CMN_INC_LIST} "${COMMON_INC_DIR}/rocm_smi.h")
 set(CMN_INC_LIST ${CMN_INC_LIST} "${SHR_MUTEX_DIR}/shared_mutex.h")
+
+# Require doxygen and latex when requesting to build the docs
+if (ROCM_SMI_BUILD_DOCS)
+  find_package(Doxygen REQUIRED)
+  find_package(LATEX REQUIRED COMPONENTS PDFLATEX)
+endif()
 
 add_subdirectory("rocm_smi")
 add_subdirectory("oam")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,10 @@ endif()
 ## Include common cmake modules
 include(utils)
 
+if (NOT DEFINED CPACK_RESOURCE_FILE_LICENSE)
+    set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/License.txt")
+endif()
+
 set(ROCM_SMI "rocm_smi")
 set(ROCM_SMI_COMPONENT "lib${ROCM_SMI}")
 set(ROCM_SMI_TARGET "${ROCM_SMI}64")
@@ -170,7 +174,8 @@ install(FILES
 install(EXPORT rocm_smiTargets DESTINATION
   "${ROCM_SMI}/lib/cmake" COMPONENT dev)
 
-
+#License file
+install( FILES ${CPACK_RESOURCE_FILE_LICENSE} DESTINATION share/doc/smi-lib RENAME LICENSE.txt)
 
 ###########################
 # Packaging directives

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,6 +175,7 @@ install(EXPORT rocm_smiTargets DESTINATION
   "${ROCM_SMI}/lib/cmake" COMPONENT dev)
 
 #License file
+set(CPACK_RPM_PACKAGE_LICENSE "NCSA")
 install( FILES ${CPACK_RESOURCE_FILE_LICENSE} DESTINATION share/doc/smi-lib RENAME LICENSE.txt)
 
 ###########################

--- a/oam/CMakeLists.txt
+++ b/oam/CMakeLists.txt
@@ -109,12 +109,12 @@ install(FILES ${COMMON_SRC_ROOT}/oam/include/oam/oam_mapi.h
                                         DESTINATION oam/include/oam)
 
 # Generate Doxygen documentation
-if (DOXYGEN_FOUND)
+if (ROCM_SMI_BUILD_DOCS)
   configure_file(${OAM_DOCS_DIR}/docs/rsmi_doxygen.cfg
                                    ${OAM_DOCS_DIR}/Doxyfile @ONLY)
   add_custom_target(doc
          ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
          WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
           COMMENT "Generating AMD OAM API documentation with Doxygen" VERBATIM)
-endif(DOXYGEN_FOUND)
+endif(ROCM_SMI_BUILD_DOCS)
 

--- a/rocm_smi/CMakeLists.txt
+++ b/rocm_smi/CMakeLists.txt
@@ -149,34 +149,28 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/bindings_link
 
 
 # Generate Doxygen documentation
-find_package(Doxygen)
-find_package(LATEX COMPONENTS PDFLATEX)
-
-if (DOXYGEN_FOUND AND LATEX_FOUND)
+if (ROCM_SMI_BUILD_DOCS)
   set (RSMI_MANUAL_NAME "ROCm_SMI_Manual")
   configure_file(${CMAKE_CURRENT_SOURCE_DIR}/docs/amd_smi_doxygen.cfg
-                                   ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile @ONLY)
+                 ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile @ONLY)
 
   add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/latex/refman.tex
         COMMAND ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
         DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/docs/amd_smi_doxygen.cfg
                 "${COMMON_INC_DIR}/rocm_smi.h"
-         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
   add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/latex/refman.pdf
-         COMMAND make  > /dev/null
-         COMMAND cp  ${CMAKE_CURRENT_BINARY_DIR}/latex/refman.pdf
+        COMMAND make  > /dev/null
+        COMMAND cp  ${CMAKE_CURRENT_BINARY_DIR}/latex/refman.pdf
                   ${CMAKE_CURRENT_SOURCE_DIR}/docs/${RSMI_MANUAL_NAME}_new.pdf
-         DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/latex/refman.tex
-         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/latex)
+        DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/latex/refman.tex
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/latex)
 
   add_custom_target(docs DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/latex/refman.pdf)
 
   add_dependencies(${ROCM_SMI_TARGET} docs)
   install(FILES ${CMAKE_CURRENT_BINARY_DIR}/latex/refman.pdf
-                         DESTINATION ${ROCM_SMI}/docs/${RSMI_MANUAL_NAME}.pdf)
+          DESTINATION ${ROCM_SMI}/docs/${RSMI_MANUAL_NAME}.pdf)
   install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/../README.md
-                          DESTINATION ${ROCM_SMI}/docs/)
-else()
-  message("Doxygen or Latex is not found. Will not generate documents.")
-endif(DOXYGEN_FOUND AND LATEX_FOUND)
-
+          DESTINATION ${ROCM_SMI}/docs/)
+endif(ROCM_SMI_BUILD_DOCS)

--- a/src/rocm_smi_device.cc
+++ b/src/rocm_smi_device.cc
@@ -630,7 +630,7 @@ int Device::writeDevInfoStr(DevInfoTypes type, std::string valStr) {
     ret = RSMI_STATUS_NOT_SUPPORTED;
   }
   fs.close();
-  
+
   return ret;
 }
 
@@ -742,7 +742,8 @@ int Device::readDevInfoMultiLineStr(DevInfoTypes type,
     return 0;
   }
   // Remove any *trailing* empty (whitespace) lines
-  while (retVec->back().find_first_not_of(" \t\n\v\f\r") == std::string::npos) {
+  while (retVec->size() != 0 &&
+        retVec->back().find_first_not_of(" \t\n\v\f\r") == std::string::npos) {
     retVec->pop_back();
   }
   return 0;


### PR DESCRIPTION
Closes #94, ref https://github.com/spack/spack/pull/28842

Only build docs when requested, and when requested, require
doxygen/latex dependencies.
