### PR TITLE
Exit with non-zero exit code if driverInitialized fails

### DIFF
--- a/python_smi_tools/rocm_smi.py
+++ b/python_smi_tools/rocm_smi.py
@@ -2662,7 +2662,7 @@ def initializeRsmi():
             exit(ret_init)
     else:
         logging.error('Driver not initialized (amdgpu not found in modules)')
-        exit(0)
+        exit(1)
 
 
 def isAmdDevice(device):


### PR DESCRIPTION
An exit code of zero implies the code executed with no errors. 